### PR TITLE
feat(android): Add different app name for debug builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -56,6 +56,7 @@ android {
         }
         debug {
             applicationIdSuffix '.debug'
+            resValue "string", "app_name", "@string/app_name_debug"
         }
     }
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.health.READ_TOTAL_CALORIES_BURNED"/>
     <uses-permission android:name="android.permission.READ_PRIVILEGED_PHONE_STATE"/>
     <application
-        android:label="hackathon"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name" translatable="false">FitnessApp</string>
+    <string name="app_name_debug" translatable="false">Debug-FitnessApp</string>
+</resources>


### PR DESCRIPTION
This change sets a different app name for debug builds to easily distinguish them. It is part of issue #3

The names are now Debug-FitnessApp and FitnessApp
![FitnessApp_Names](https://github.com/user-attachments/assets/228fbc67-a63a-4b3a-9bd4-6e1d9bc10f14)
