### PR TITLE
feat(android): Add workflow to build release APK on pull requests

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -25,7 +25,7 @@ jobs:
       - name: "Install flutter dependencies"
         run: flutter pub get
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
            name: Releases
            path: |


### PR DESCRIPTION
This change introduces a GitHub Actions workflow to automatically build a release APK whenever a pull request is opened against
 the `main` branch.