### PR TITLE
:recycle: Update activity details time format

### DIFF
--- a/lib/presentation/activity_details/widget/header_details.dart
+++ b/lib/presentation/activity_details/widget/header_details.dart
@@ -35,7 +35,7 @@ class HeaderDetails extends StatelessWidget {
                   Row(
                     children: [
                       Text(
-                          "${DateFormat("d MMM y H:s").format(start)} - ${DateFormat("H:s").format(end)}")
+                          "${DateFormat("d MMM y HH:mm").format(start)} - ${DateFormat("HH:mm").format(end)}")
                     ],
                   )
                 ]),


### PR DESCRIPTION
Changed the time format in activity details header from `H:s` to `HH:mm`.

