### PR TITLE
Fix inconsistent step of day interval

### DIFF
--- a/lib/presentation/today/view_model/stats_view_model.dart
+++ b/lib/presentation/today/view_model/stats_view_model.dart
@@ -15,14 +15,16 @@ class StatsViewModel extends StateNotifier<StatsState> {
 
   Future<void> fetchStats() async {
     DateTime now = DateTime.now();
-    var lastMidnight = DateTime(now.year, now.month, now.day);
+    final startOfDay = DateTime(now.year, now.month, now.day);
+    final endOfDay =
+    startOfDay.add(const Duration(hours: 23, minutes: 59, seconds: 59));
     int steps = await ref
         .read(localHealthRepositoryProvider)
-        .getStepsInInterval(lastMidnight, now);
+        .getStepsInInterval(startOfDay, endOfDay);
     double distance = await ref
         .read(localHealthRepositoryProvider)
         .getDistanceInInterval(
-            lastMidnight, now) / 1000;
+            startOfDay, endOfDay) / 1000;
     int sleep = await ref
         .read(localHealthRepositoryProvider)
         .getSleepFromDate(now.subtract(const Duration(days: 1)));


### PR DESCRIPTION
- In the badges a 24 hour interval is used, in the today screen a 0.00 until current time was used.
- This caused some weird inconsistencies between the step amount of these two components
- Because of that it was unified.

This pull request includes a change to the `StatsViewModel` class in the `lib/presentation/today/view_model/stats_view_model.dart` file. The change updates the time interval used for fetching health statistics to cover the entire day from start to end.

Time interval update:

* [`lib/presentation/today/view_model/stats_view_model.dart`](diffhunk://#diff-3d33db26e691ac90dafcfa2cb8578bc15ae712031aa379f95c47e0acf4c5945cL18-R27): Changed the time interval variables from `lastMidnight` and `now` to `startOfDay` and `endOfDay` to ensure the entire day is covered when fetching steps and distance data.