### PR TITLE
Fix invalid int to boolean cast

### DIFF
--- a/lib/data/repositories/badge_repository_impl.dart
+++ b/lib/data/repositories/badge_repository_impl.dart
@@ -64,7 +64,7 @@ class BadgeRepositoryImpl implements BadgeRepository {
           category: AchievementBadgeCategory.values[data['category']],
           threshold: data['threshold'],
           iconPath: data['iconPath'],
-          isRepeatable: data['isRepeatable'] ?? 0,
+          isRepeatable: data['isRepeatable'] == 0 ? false : true,
           epValue: data['epValue'] ?? 0,
         );
       }).toList();


### PR DESCRIPTION
This pull request includes an important change to the `BadgeRepositoryImpl` class in the `lib/data/repositories/badge_repository_impl.dart` file. The change ensures that the `isRepeatable` field is correctly interpreted as a boolean value.

* [`lib/data/repositories/badge_repository_impl.dart`](diffhunk://#diff-a5d31f0bcee322da666ab358d4acdb8b9cf466eb87a5b6fc56ef232051514db8L67-R67): Modified the `isRepeatable` field to be interpreted as a boolean value instead of an integer.