### PR TITLE
Fix write workout data for activities other than walking/running

### DIFF
--- a/lib/data/repositories/local_health_impl.dart
+++ b/lib/data/repositories/local_health_impl.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:activity_tracking/model/activity.dart' as tracking_activity;
+import 'package:activity_tracking/model/activity_type.dart';
 import 'package:health/health.dart';
 import 'package:logging/logging.dart';
 import 'package:movetopia/data/model/activity.dart';
@@ -267,7 +268,8 @@ interface class LocalHealthRepoImpl extends LocalHealthRepository {
             type: HealthDataType.STEPS,
             startTime: startTime,
             endTime: endTime);
-      } else {
+      } else if (preview.activityType == ActivityType.walking ||
+          preview.activityType == ActivityType.running) {
         return null;
       }
       success = await Health().writeWorkoutData(

--- a/lib/presentation/tracking/widgets/tracking_active.dart
+++ b/lib/presentation/tracking/widgets/tracking_active.dart
@@ -1,4 +1,5 @@
 import 'package:activity_tracking/model/activity.dart';
+import 'package:activity_tracking/model/activity_type.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -35,7 +36,8 @@ class TrackingRecording extends StatelessWidget {
               Icons.speed,
               AppLocalizations.of(context)!.activity_current_speed,
               "${activity!.locations!.isEmpty ? "--" : ((activity?.locations?.entries.last.value.speed ?? 0) * 10).roundToDouble() / 10} km/h"),
-        if (activity?.steps != null)
+        if (activity?.steps != null &&
+            activity?.activityType != ActivityType.biking)
           _buildDetailEntry(
               context,
               Icons.nordic_walking,
@@ -83,7 +85,7 @@ class TrackingRecording extends StatelessWidget {
           style: ElevatedButton.styleFrom(
               backgroundColor: Theme.of(context).colorScheme.error,
               shape: const CircleBorder(),
-              padding: EdgeInsets.all(24)),
+              padding: const EdgeInsets.all(24)),
           child: Icon(
             Icons.stop,
             size: 24,


### PR DESCRIPTION
- Modified `LocalHealthRepoImpl` to not write workout data for activities other than walking or running, fixing a bug where workout data was being incorrectly written for activities like biking.
- Updated `TrackingActive` widget to not show steps for biking activities.

This pull request includes changes to handle different activity types in the tracking feature and a minor UI improvement. The most important changes involve adding support for `ActivityType` in various parts of the codebase and refining the display logic for steps.

Changes related to activity types:

* [`lib/data/repositories/local_health_impl.dart`](diffhunk://#diff-99442f8cf53d535dc947e240c47d72949d679badbe5c1f253d9d99974446d774R4): Imported `activity_type.dart` and added conditions to handle `ActivityType.walking` and `ActivityType.running` in the `LocalHealthRepoImpl` class. [[1]](diffhunk://#diff-99442f8cf53d535dc947e240c47d72949d679badbe5c1f253d9d99974446d774R4) [[2]](diffhunk://#diff-99442f8cf53d535dc947e240c47d72949d679badbe5c1f253d9d99974446d774L270-R272)
* [`lib/presentation/tracking/widgets/tracking_active.dart`](diffhunk://#diff-6321dbec87c91b717c14f686f4ba1bc8f0adb34ea26bce120c9630fd5d3093eeR2): Imported `activity_type.dart` and updated the `TrackingRecording` class to exclude steps display for `ActivityType.biking`. [[1]](diffhunk://#diff-6321dbec87c91b717c14f686f4ba1bc8f0adb34ea26bce120c9630fd5d3093eeR2) [[2]](diffhunk://#diff-6321dbec87c91b717c14f686f4ba1bc8f0adb34ea26bce120c9630fd5d3093eeL38-R40)

UI improvement:

* [`lib/presentation/tracking/widgets/tracking_active.dart`](diffhunk://#diff-6321dbec87c91b717c14f686f4ba1bc8f0adb34ea26bce120c9630fd5d3093eeL86-R88): Changed the `padding` property in the `ElevatedButton` style to use a constant value.