### PR TITLE
Fix import statement for location model

### DIFF
--- a/lib/presentation/tracking/view_model/tracking_state.dart
+++ b/lib/presentation/tracking/view_model/tracking_state.dart
@@ -1,6 +1,6 @@
-import 'package:activity_tracking/model/Location.dart';
 import 'package:activity_tracking/model/activity.dart';
 import 'package:activity_tracking/model/activity_type.dart';
+import 'package:activity_tracking/model/location.dart';
 import 'package:logging/logging.dart';
 
 class TrackingState {


### PR DESCRIPTION
This pull request includes a small change to the `lib/presentation/tracking/view_model/tracking_state.dart` file. The change corrects the import statement for the `Location` model to use the correct lowercase filename.

* Corrected import statement for `Location` model to use `location.dart` instead of `Location.dart`.