### PR TITLE
Fix badge update logic by uncommenting badgeService check and upda…

### DIFF
--- a/lib/domain/service/app_startup_service.dart
+++ b/lib/domain/service/app_startup_service.dart
@@ -43,7 +43,7 @@ class AppStartupService {
     // Überprüfe und aktualisiere die Badges
     try {
       logger.info('Checking and updating badges...');
-      // await badgeService.checkAndUpdateBadges();
+      await badgeService.checkAndUpdateBadges();
       logger.info('Badge update completed.');
     } catch (e) {
       logger.severe('Error updating badges: $e');


### PR DESCRIPTION
…te call
This pull request includes a small but important change to the `AppStartupService` class in the `lib/domain/service/app_startup_service.dart` file. The change involves uncommenting a line of code to ensure that the badge update process is executed during the application startup.

* [`lib/domain/service/app_startup_service.dart`](diffhunk://#diff-a9c23adafa70200e249717b23d6509be1d81afb160e902ecc3b4614ab43a4c17L46-R46): Uncommented the call to `badgeService.checkAndUpdateBadges()` to ensure badges are checked and updated during app startup.