### PR TITLE
♻️ Adjust activity start and end times to account for timezone offset

### DIFF
--- a/lib/presentation/activities/details/widget/hearth_frequency_graph.dart
+++ b/lib/presentation/activities/details/widget/hearth_frequency_graph.dart
@@ -120,8 +120,9 @@ class HearthFrequencyGraph extends StatelessWidget {
             getTooltipColor: (touchedSpot) => _getColorForValue(touchedSpot.y),
           )),
       data: data,
-      activityStartTime: activityStartTime,
-      activityEndTime: activityEndTime,
+      activityStartTime:
+          activityStartTime.subtract(activityStartTime.timeZoneOffset),
+      activityEndTime: activityEndTime.subtract(activityEndTime.timeZoneOffset),
       title: l10n.activity_heart_frequency,
       barAreaData: BarAreaData(
         show: true,


### PR DESCRIPTION
This pull request includes a change to the `HearthFrequencyGraph` widget in the `lib/presentation/activities/details/widget/hearth_frequency_graph.dart` file. The change adjusts the `activityStartTime` and `activityEndTime` to account for the time zone offset.

* [`lib/presentation/activities/details/widget/hearth_frequency_graph.dart`](diffhunk://#diff-ee699a1b9218cb266a1c3017c2bbcd065a5b19de74523564d6377cfbd605dd1dL123-R125): Modified `activityStartTime` and `activityEndTime` to subtract the time zone offset.