### PR TITLE
Fix environment variable name for keystore setup

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -93,7 +93,7 @@ platform :android do
           
           # Create keystore file from base64 encoded string
           keystore_path = File.join(Dir.pwd, "..", "app", "keystore.jks")
-          File.write(keystore_path, Base64.decode64(ENV["MT_KEYSTORE_BASE64"]))
+          File.write(keystore_path, Base64.decode64(ENV["KEYSTORE_BASE64"]))
           
           # Set environment variables for the keystore
           ENV["KEYSTORE_PATH"] = keystore_path
@@ -102,9 +102,9 @@ platform :android do
           # Local development setup
           ENV["KEYSTORE_PATH"] = ENV["MT_KEYSTORE_PATH"]
       end
-      ENV["KEYSTORE_PASSWORD"] = ENV["MT_KEYSTORE_PASSWORD"]
-      ENV["KEY_ALIAS"] = ENV["MT_KEY_ALIAS"]
-      ENV["KEY_PASSWORD"] = ENV["MT_KEY_PASSWORD"]
+      ENV["KEYSTORE_PASSWORD"] = ENV["KEYSTORE_PASSWORD"] || ENV["MT_KEYSTORE_PASSWORD"]
+      ENV["KEY_ALIAS"] = ENV["KEY_ALIAS"] || ENV["MT_KEY_ALIAS"]
+      ENV["KEY_PASSWORD"] = ENV["KEY_PASSWORD"] || ENV["MT_KEY_PASSWORD"]
   end
 
   # Helper to configure GitHub access with token
@@ -392,9 +392,10 @@ DART
   end
   
   # 3. Basic release build - just build APK without version, tag or release
-  desc "Build release APK without creating a release or tag"
+  desc "Build release APK with versioning"
   lane :build_release do
-    UI.message("Starting basic release build")
+    UI.message("Starting release APK build")
+
     # Setup keystore properties
     setup_keystore
     

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: cc1c20a58f4c251347065f40221ced803cfb5d4e
+      resolved-ref: "939232a8af30f24547087102e182f5a7973735ec"
       url: "https://github.com/Jozys/activity_tracking.git"
     source: git
     version: "0.0.1"


### PR DESCRIPTION
This pull request includes several changes to the `android/fastlane/Fastfile` to improve the handling of environment variables and update the build release description. The most important changes include updating environment variable references, adding fallback values for certain environment variables, and modifying the description for the release build.

Environment variable updates:

* [`android/fastlane/Fastfile`](diffhunk://#diff-d0c99c3583617d28a3669e90c98158993dfbd7a57c6e010b1a70e2a8acaed5a6L96-R96): Updated the environment variable reference from `ENV["MT_KEYSTORE_BASE64"]` to `ENV["KEYSTORE_BASE64"]` when creating the keystore file.

* [`android/fastlane/Fastfile`](diffhunk://#diff-d0c99c3583617d28a3669e90c98158993dfbd7a57c6e010b1a70e2a8acaed5a6L105-R107): Added fallback values for `KEYSTORE_PASSWORD`, `KEY_ALIAS`, and `KEY_PASSWORD` environment variables to use `MT_KEYSTORE_PASSWORD`, `MT_KEY_ALIAS`, and `MT_KEY_PASSWORD` respectively if the primary values are not set.

Build release description update:

* [`android/fastlane/Fastfile`](diffhunk://#diff-d0c99c3583617d28a3669e90c98158993dfbd7a57c6e010b1a70e2a8acaed5a6L395-R398): Modified the description for the `build_release` lane from "Build release APK without creating a release or tag" to "Build release APK with versioning" and updated the message from "Starting basic release build" to "Starting release APK build".