### PR TITLE
🐛 Fix missing authState status for allowing activityDetails Fetching

### DIFF
--- a/lib/presentation/activities/details/screen/activity_details.dart
+++ b/lib/presentation/activities/details/screen/activity_details.dart
@@ -36,7 +36,9 @@ class ActivityDetailsScreen extends HookConsumerWidget {
           var activityDetailNotifier =
               ref.read(activityDetailedViewModelProvider.notifier);
           activityDetailNotifier.setLoading(true);
-          if (authState == HealthAuthViewModelState.authorized) {
+          if (authState == HealthAuthViewModelState.authorized ||
+              authState ==
+                  HealthAuthViewModelState.authorizedWithHistoricalAccess) {
             await fetchDetailedActivity();
           }
 


### PR DESCRIPTION
This pull request includes a change to the `ActivityDetailsScreen` in the `activity_details.dart` file. The change modifies the condition under which detailed activity data is fetched to include an additional authorization state.

Authorization condition update:

* [`lib/presentation/activities/details/screen/activity_details.dart`](diffhunk://#diff-7de7ecaa5049c970d5d1936f0651b260dc61f35c6a4d3b9850684be7e0f41602L39-R41): Modified the condition to check for `HealthAuthViewModelState.authorizedWithHistoricalAccess` in addition to `HealthAuthViewModelState.authorized` before fetching detailed activity data.