### PR TITLE
🐛 Add missing permission to read active calories burned in AndroidManifest.xml

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <uses-permission android:name="androidx.health.permission.Distance.READ" />
     <uses-permission android:name="androidx.health.permission.Distance.WRITE" />
     <uses-permission android:name="android.permission.health.READ_TOTAL_CALORIES_BURNED" />
+    <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED" />
     <uses-permission android:name="android.permission.READ_PRIVILEGED_PHONE_STATE" />
     <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_HISTORY" />
     <uses-permission android:name="android.permission.MANAGE_HEALTH_DATA" />
@@ -61,8 +62,8 @@
         <activity
             android:name=".PrivacyPolicyActivity"
             android:exported="true"
-            android:theme="@style/Theme.AppCompat.NoActionBar">
-        </activity>
+            android:theme="@style/Theme.AppCompat.NoActionBar"></activity>
+
         <activity-alias
             android:name="ViewPermissionUsageActivity"
             android:exported="true"


### PR DESCRIPTION
This pull request includes changes to the `android/app/src/main/AndroidManifest.xml` file to update permissions and clean up the code formatting for activities.

Permissions update:
* Added a new permission for reading active calories burned (`android.permission.health.READ_ACTIVE_CALORIES_BURNED`).

Code formatting:
* Cleaned up the formatting of the `PrivacyPolicyActivity` element by removing unnecessary line breaks

- Closes #92 