### PR TITLE
🐛 Fix UTC adjustment for health data time range and improve tooltip d…

### DIFF
--- a/lib/data/service/health_service_impl.dart
+++ b/lib/data/service/health_service_impl.dart
@@ -75,6 +75,9 @@ class HealthServiceImpl implements HealthService {
       final cachedData = _cache[fullMatchKey] as List<HealthDataPoint>;
       // Filter for the exact time range requested
       log("Cache hit for $types");
+      //  The time needs to be adjusted to UTC
+      start = start.subtract(start.timeZoneOffset);
+      end = end.subtract(end.timeZoneOffset);
       return cachedData.where((point) {
         return (point.dateFrom
                     .isAfter(start.subtract(const Duration(seconds: 1))) ||

--- a/lib/presentation/activities/details/view_model/activity_detail_view_model.dart
+++ b/lib/presentation/activities/details/view_model/activity_detail_view_model.dart
@@ -31,7 +31,6 @@ class ActivityDetailedViewModel extends StateNotifier<ActivityDetailState> {
           end: activityDetailed.end,
           heartRates: activityDetailed.heartRates,
           speed: activityDetailed.speed,
-          // icon: preview.icon,
           sourceId: activityDetailed.sourceId);
       activity.icon = preview.icon != null && preview.icon!.isNotEmpty
           ? preview.icon

--- a/lib/presentation/activities/details/widget/hearth_frequency_graph.dart
+++ b/lib/presentation/activities/details/widget/hearth_frequency_graph.dart
@@ -105,7 +105,7 @@ class HearthFrequencyGraph extends StatelessWidget {
             getTooltipItems: (touchedSpots) {
               return touchedSpots.map((touchedSpot) {
                 return LineTooltipItem(
-                  '${touchedSpot.y} bpm',
+                  '${touchedSpot.y.toInt()} bpm',
                   TextStyle(
                     color:
                         (touchedSpot.bar.color?.computeLuminance() ?? 0) > 0.5


### PR DESCRIPTION
…isplay for heart frequency graph

# 🚀 Pull Request

## Brief Description
This pull request resolves issues with the cache and utc times of the heart frequency data coming from HealthConnect. It also casts the data value to an integer as bpm is normally considered to be an integer

## GitHub Copilot Text
This pull request includes several changes to the `lib/data/service/health_service_impl.dart`, `lib/presentation/activities/details/view_model/activity_detail_view_model.dart`, and `lib/presentation/activities/details/widget/hearth_frequency_graph.dart` files. The changes primarily focus on adjusting time to UTC, cleaning up commented code, and improving the display of heart rate data.

Adjustments to time handling:

* [`lib/data/service/health_service_impl.dart`](diffhunk://#diff-3e53fc5b1dfa9fdd52f251a640e34d6e0d9885b33745f4471df5785f1d0dabe0R78-R80): Adjusted the `start` and `end` times to UTC by subtracting the time zone offset.

Code cleanup:

* [`lib/presentation/activities/details/view_model/activity_detail_view_model.dart`](diffhunk://#diff-18cd0d0c1811259fd4ba54fdd013026e4407fcfd8396025bae89e1ebe8e96557L34): Removed a commented-out line of code related to the `icon` property.

Display improvements:

* [`lib/presentation/activities/details/widget/hearth_frequency_graph.dart`](diffhunk://#diff-ee699a1b9218cb266a1c3017c2bbcd065a5b19de74523564d6377cfbd605dd1dL108-R108): Modified the tooltip to display heart rate values as integers instead of floating-point numbers.