### PR TITLE
Add resources.properties for locale configuration of activity_tracking

### DIFF
--- a/android/app/src/main/res/resources.properties
+++ b/android/app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en-US

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "939232a8af30f24547087102e182f5a7973735ec"
+      resolved-ref: "3f5fa4d122126adbda9c6ea441ec149b9d0c621c"
       url: "https://github.com/Jozys/activity_tracking.git"
     source: git
     version: "0.0.1"


### PR DESCRIPTION
This pull request includes a small change to the `android/app/src/main/res/resources.properties` file. The change sets the unqualified resource locale to `en-US`.