### PR TITLE
Add margin for system navigation

### DIFF
--- a/lib/presentation/challenges/badgeLists/widgets/category_badges_section.dart
+++ b/lib/presentation/challenges/badgeLists/widgets/category_badges_section.dart
@@ -58,64 +58,68 @@ class _CategoryBadgesSectionState extends ConsumerState<CategoryBadgesSection> {
         // Get next badge (with lowest threshold)
         final nextBadge = remainingBadges.first;
 
-        return Padding(
-            padding:
-                const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
-            child: SingleChildScrollView(
-                child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _buildProgressCard(),
+        return Container(
+            margin: EdgeInsets.only(
+                bottom: MediaQuery.of(context).viewPadding.bottom),
+            child: Padding(
+                padding:
+                    const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                child: SingleChildScrollView(
+                    child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildProgressCard(),
 
-                // Next badge
-                Padding(
-                  padding: const EdgeInsets.only(top: 16.0, bottom: 8.0),
-                  child: Text(
-                    l10n.badge_next_goal,
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
-                  ),
-                ),
+                    // Next badge
+                    Padding(
+                      padding: const EdgeInsets.only(top: 16.0, bottom: 8.0),
+                      child: Text(
+                        l10n.badge_next_goal,
+                        style:
+                            Theme.of(context).textTheme.titleMedium?.copyWith(
+                                  fontWeight: FontWeight.bold,
+                                ),
+                      ),
+                    ),
 
-                BadgeItem(
-                  badge: nextBadge,
-                  currentValue: widget.currentValue,
-                  showProgress: true,
-                ),
+                    BadgeItem(
+                      badge: nextBadge,
+                      currentValue: widget.currentValue,
+                      showProgress: true,
+                    ),
 
-                // Other remaining badges (expandable)
-                if (remainingBadges.length > 1)
-                  _buildExpandableSection(
-                    title:
-                        "${l10n.badge_upcoming_badges} (${remainingBadges.length - 1})",
-                    isExpanded: _showRemainingBadges,
-                    onTap: () => setState(
-                        () => _showRemainingBadges = !_showRemainingBadges),
-                    badgeWidgets: remainingBadges
-                        .skip(1)
-                        .map((badge) => BadgeItem(
-                              badge: badge,
-                              currentValue: widget.currentValue,
-                              showProgress: true,
-                            ))
-                        .toList(),
-                  ),
+                    // Other remaining badges (expandable)
+                    if (remainingBadges.length > 1)
+                      _buildExpandableSection(
+                        title:
+                            "${l10n.badge_upcoming_badges} (${remainingBadges.length - 1})",
+                        isExpanded: _showRemainingBadges,
+                        onTap: () => setState(
+                            () => _showRemainingBadges = !_showRemainingBadges),
+                        badgeWidgets: remainingBadges
+                            .skip(1)
+                            .map((badge) => BadgeItem(
+                                  badge: badge,
+                                  currentValue: widget.currentValue,
+                                  showProgress: true,
+                                ))
+                            .toList(),
+                      ),
 
-                // Achieved badges (expandable)
-                if (achievedBadges.isNotEmpty)
-                  _buildExpandableSection(
-                    title:
-                        "${l10n.badge_achieved_badges} (${achievedBadges.length})",
-                    isExpanded: _showAchievedBadges,
-                    onTap: () => setState(
-                        () => _showAchievedBadges = !_showAchievedBadges),
-                    badgeWidgets: achievedBadges
-                        .map((badge) => BadgeItem(badge: badge))
-                        .toList(),
-                  ),
-              ],
-            )));
+                    // Achieved badges (expandable)
+                    if (achievedBadges.isNotEmpty)
+                      _buildExpandableSection(
+                        title:
+                            "${l10n.badge_achieved_badges} (${achievedBadges.length})",
+                        isExpanded: _showAchievedBadges,
+                        onTap: () => setState(
+                            () => _showAchievedBadges = !_showAchievedBadges),
+                        badgeWidgets: achievedBadges
+                            .map((badge) => BadgeItem(badge: badge))
+                            .toList(),
+                      ),
+                  ],
+                ))));
       },
     );
   }

--- a/lib/presentation/challenges/streak/screen/streak_details_screen.dart
+++ b/lib/presentation/challenges/streak/screen/streak_details_screen.dart
@@ -68,33 +68,36 @@ class StreakDetailsScreen extends ConsumerWidget {
     GlobalKey<RefreshIndicatorState> refreshIndicatorKey,
   ) {
     return RefreshIndicator(
-      key: refreshIndicatorKey,
-      onRefresh: () => _refreshData(context, ref),
-      child: Column(
-        children: [
-          // Header mit Streak-Zähler
-          _buildHeader(context, streakCount, ref),
+        key: refreshIndicatorKey,
+        onRefresh: () => _refreshData(context, ref),
+        child: Container(
+          margin: EdgeInsets.only(
+              bottom: MediaQuery.of(context).viewPadding.bottom),
+          child: Column(
+            children: [
+              // Header mit Streak-Zähler
+              _buildHeader(context, streakCount, ref),
 
-          // Kalender
-          Expanded(
-            child: SingleChildScrollView(
-              physics: const AlwaysScrollableScrollPhysics(),
-              // Wichtig für RefreshIndicator
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                children: [
-                  _buildCalendar(context, days, l10n, ref),
-                  const SizedBox(height: 24),
-                  _buildLegend(context, l10n),
-                  const SizedBox(height: 16),
-                  _buildCompletedDaysText(context, days, l10n),
-                ],
+              // Kalender
+              Expanded(
+                child: SingleChildScrollView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  // Wichtig für RefreshIndicator
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    children: [
+                      _buildCalendar(context, days, l10n, ref),
+                      const SizedBox(height: 24),
+                      _buildLegend(context, l10n),
+                      const SizedBox(height: 16),
+                      _buildCompletedDaysText(context, days, l10n),
+                    ],
+                  ),
+                ),
               ),
-            ),
+            ],
           ),
-        ],
-      ),
-    );
+        ));
   }
 
   Widget _buildHeader(

--- a/lib/presentation/profile/screen/permissions_settings_screen.dart
+++ b/lib/presentation/profile/screen/permissions_settings_screen.dart
@@ -34,316 +34,320 @@ class PermissionsSettingsScreen extends HookConsumerWidget {
     ]);
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n.permission_settings_title),
-      ),
-      body: SingleChildScrollView(
-        child: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                padding: const EdgeInsets.all(16),
-                decoration: BoxDecoration(
-                  color:
-                      theme.colorScheme.primaryContainer.withValues(alpha: 0.3),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        Icon(
-                          Icons.info_outline,
-                          color: theme.colorScheme.primary,
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: Text(
-                            l10n.permission_settings_subtitle,
-                            style: theme.textTheme.bodyLarge,
-                          ),
-                        ),
-                      ],
+        appBar: AppBar(
+          title: Text(l10n.permission_settings_title),
+        ),
+        body: Container(
+          margin: EdgeInsets.only(
+              bottom: MediaQuery.of(context).viewPadding.bottom),
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.primaryContainer
+                          .withValues(alpha: 0.3),
+                      borderRadius: BorderRadius.circular(12),
                     ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 24),
-
-              // Required permissions section
-              SectionHeader(title: l10n.required_permissions),
-              const SizedBox(height: 16),
-
-              // Health data READ permission (required)
-              PermissionCard(
-                icon: Icons.favorite,
-                title: l10n.permission_health_read_title,
-                description: l10n.permission_health_read_description,
-                status: permissionsState.healthPermissionStatus
-                    ? PermissionStatus.granted
-                    : PermissionStatus.denied,
-                onRequestPermission: () {
-                  // Zeige Ladeindikator
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Row(
-                        children: [
-                          const SizedBox(
-                            width: 20,
-                            height: 20,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              color: Colors.white,
-                            ),
-                          ),
-                          const SizedBox(width: 16),
-                          Text(l10n.requesting_health_permissions),
-                        ],
-                      ),
-                      duration: const Duration(seconds: 1),
-                    ),
-                  );
-
-                  // Request health data permission
-                  ref.read(healthViewModelProvider.notifier).authorize();
-                  ref
-                      .read(permissionsProvider.notifier)
-                      .requestHealthPermission();
-                },
-                onOpenSettings: () => openAppSettings(),
-                isRequired: true,
-              ),
-
-              const SizedBox(height: 24),
-
-              // Optional permissions section
-              SectionHeader(title: l10n.optional_permissions),
-              const SizedBox(height: 16),
-
-              // Health data WRITE permission (optional)
-              PermissionCard(
-                icon: Icons.drive_file_rename_outline,
-                title: l10n.permission_health_write_title,
-                description: l10n.permission_health_write_description,
-                status: permissionsState.healthWritePermissionStatus
-                    ? PermissionStatus.granted
-                    : PermissionStatus.denied,
-                onRequestPermission: () {
-                  // Überprüfe zuerst, ob Read-Berechtigung vorhanden ist
-                  if (!permissionsState.healthPermissionStatus) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text(
-                            'Bitte erteile zuerst die Leseberechtigung für Gesundheitsdaten'),
-                        backgroundColor: theme.colorScheme.error,
-                        duration: const Duration(seconds: 2),
-                      ),
-                    );
-                    return;
-                  }
-
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Row(
-                        children: [
-                          const SizedBox(
-                            width: 20,
-                            height: 20,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              color: Colors.white,
-                            ),
-                          ),
-                          const SizedBox(width: 16),
-                          Text(l10n.requesting_health_write_permissions),
-                        ],
-                      ),
-                      duration: const Duration(seconds: 1),
-                    ),
-                  );
-
-                  // Request optional WRITE-Permissions
-                  ref
-                      .read(permissionsProvider.notifier)
-                      .requestHealthWritePermission()
-                      .then((_) {
-                    // Nach dem Anfordern den Status prüfen
-                    final writeGranted = ref
-                        .read(permissionsProvider)
-                        .healthWritePermissionStatus;
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text(writeGranted
-                            ? l10n.health_write_granted
-                            : l10n.health_write_denied),
-                        backgroundColor: writeGranted
-                            ? theme.colorScheme.primary
-                            : theme.colorScheme.error,
-                        duration: const Duration(seconds: 2),
-                      ),
-                    );
-                  });
-                },
-                onOpenSettings: () => openAppSettings(),
-                isRequired: false,
-              ),
-
-              const SizedBox(height: 16),
-
-              // Historical Health Data permission (optional)
-              PermissionCard(
-                icon: Icons.history,
-                title: l10n.permission_health_historical_title,
-                description: l10n.permission_health_historical_description,
-                status: permissionsState.healthHistoricalPermissionStatus
-                    ? PermissionStatus.granted
-                    : PermissionStatus.denied,
-                onRequestPermission: () {
-                  // Überprüfe zuerst, ob Read-Berechtigung vorhanden ist
-                  if (!permissionsState.healthPermissionStatus) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text(
-                            'Bitte erteile zuerst die Leseberechtigung für Gesundheitsdaten'),
-                        backgroundColor: theme.colorScheme.error,
-                        duration: const Duration(seconds: 2),
-                      ),
-                    );
-                    return;
-                  }
-
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Row(
-                        children: [
-                          const SizedBox(
-                            width: 20,
-                            height: 20,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              color: Colors.white,
-                            ),
-                          ),
-                          const SizedBox(width: 16),
-                          Text(l10n.requesting_health_historical_permissions),
-                        ],
-                      ),
-                      duration: const Duration(seconds: 1),
-                    ),
-                  );
-
-                  // Request optional HISTORICAL-Permissions
-                  ref
-                      .read(permissionsProvider.notifier)
-                      .requestHealthHistoricalPermission()
-                      .then((_) {
-                    // Nach dem Anfordern den Status prüfen
-                    final historicalGranted = ref
-                        .read(permissionsProvider)
-                        .healthHistoricalPermissionStatus;
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text(historicalGranted
-                            ? l10n.health_historical_granted
-                            : l10n.health_historical_denied),
-                        backgroundColor: historicalGranted
-                            ? theme.colorScheme.primary
-                            : theme.colorScheme.error,
-                        duration: const Duration(seconds: 2),
-                      ),
-                    );
-                  });
-                },
-                onOpenSettings: () => openAppSettings(),
-                isRequired: false,
-              ),
-
-              const SizedBox(height: 16),
-
-              // Location permission
-              PermissionCard(
-                icon: Icons.location_on,
-                title: l10n.permission_location_title,
-                description: l10n.permission_location_description,
-                status: permissionsState.locationPermissionStatus,
-                onRequestPermission: () => ref
-                    .read(permissionsProvider.notifier)
-                    .requestLocationPermission(),
-                onOpenSettings: () => openAppSettings(),
-                isRequired: false,
-              ),
-
-              const SizedBox(height: 16),
-
-              // Activity recognition permission
-              PermissionCard(
-                icon: Icons.directions_walk,
-                title: l10n.permission_activity_title,
-                description: l10n.permission_activity_description,
-                status: permissionsState.activityPermissionStatus,
-                onRequestPermission: () => ref
-                    .read(permissionsProvider.notifier)
-                    .requestActivityPermission(),
-                onOpenSettings: () => openAppSettings(),
-                isRequired: false,
-              ),
-
-              const SizedBox(height: 16),
-
-              // Notification permission
-              PermissionCard(
-                icon: Icons.notifications,
-                title: l10n.permission_notification_title,
-                description: l10n.permission_notification_description,
-                status: permissionsState.notificationPermissionStatus,
-                onRequestPermission: () => ref
-                    .read(permissionsProvider.notifier)
-                    .requestNotificationPermission(),
-                onOpenSettings: () => openAppSettings(),
-                isRequired: false,
-              ),
-
-              const SizedBox(height: 24),
-
-              // Hinweistext
-              Container(
-                padding: const EdgeInsets.all(16),
-                decoration: BoxDecoration(
-                  color: theme.colorScheme.surfaceContainerHighest
-                      .withValues(alpha: 0.5),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Column(
-                  children: [
-                    Row(
+                    child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Icon(
-                          Icons.help_outline,
-                          color: theme.colorScheme.onSurfaceVariant,
-                          size: 18,
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(
-                            'Hinweis: Einige Berechtigungen können nur in den Systemeinstellungen deines Geräts geändert werden.',
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: theme.colorScheme.onSurfaceVariant,
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.info_outline,
+                              color: theme.colorScheme.primary,
                             ),
-                          ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Text(
+                                l10n.permission_settings_subtitle,
+                                style: theme.textTheme.bodyLarge,
+                              ),
+                            ),
+                          ],
                         ),
                       ],
                     ),
-                  ],
-                ),
+                  ),
+                  const SizedBox(height: 24),
+
+                  // Required permissions section
+                  SectionHeader(title: l10n.required_permissions),
+                  const SizedBox(height: 16),
+
+                  // Health data READ permission (required)
+                  PermissionCard(
+                    icon: Icons.favorite,
+                    title: l10n.permission_health_read_title,
+                    description: l10n.permission_health_read_description,
+                    status: permissionsState.healthPermissionStatus
+                        ? PermissionStatus.granted
+                        : PermissionStatus.denied,
+                    onRequestPermission: () {
+                      // Zeige Ladeindikator
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Row(
+                            children: [
+                              const SizedBox(
+                                width: 20,
+                                height: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: Colors.white,
+                                ),
+                              ),
+                              const SizedBox(width: 16),
+                              Text(l10n.requesting_health_permissions),
+                            ],
+                          ),
+                          duration: const Duration(seconds: 1),
+                        ),
+                      );
+
+                      // Request health data permission
+                      ref.read(healthViewModelProvider.notifier).authorize();
+                      ref
+                          .read(permissionsProvider.notifier)
+                          .requestHealthPermission();
+                    },
+                    onOpenSettings: () => openAppSettings(),
+                    isRequired: true,
+                  ),
+
+                  const SizedBox(height: 24),
+
+                  // Optional permissions section
+                  SectionHeader(title: l10n.optional_permissions),
+                  const SizedBox(height: 16),
+
+                  // Health data WRITE permission (optional)
+                  PermissionCard(
+                    icon: Icons.drive_file_rename_outline,
+                    title: l10n.permission_health_write_title,
+                    description: l10n.permission_health_write_description,
+                    status: permissionsState.healthWritePermissionStatus
+                        ? PermissionStatus.granted
+                        : PermissionStatus.denied,
+                    onRequestPermission: () {
+                      // Überprüfe zuerst, ob Read-Berechtigung vorhanden ist
+                      if (!permissionsState.healthPermissionStatus) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(
+                                'Bitte erteile zuerst die Leseberechtigung für Gesundheitsdaten'),
+                            backgroundColor: theme.colorScheme.error,
+                            duration: const Duration(seconds: 2),
+                          ),
+                        );
+                        return;
+                      }
+
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Row(
+                            children: [
+                              const SizedBox(
+                                width: 20,
+                                height: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: Colors.white,
+                                ),
+                              ),
+                              const SizedBox(width: 16),
+                              Text(l10n.requesting_health_write_permissions),
+                            ],
+                          ),
+                          duration: const Duration(seconds: 1),
+                        ),
+                      );
+
+                      // Request optional WRITE-Permissions
+                      ref
+                          .read(permissionsProvider.notifier)
+                          .requestHealthWritePermission()
+                          .then((_) {
+                        // Nach dem Anfordern den Status prüfen
+                        final writeGranted = ref
+                            .read(permissionsProvider)
+                            .healthWritePermissionStatus;
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(writeGranted
+                                ? l10n.health_write_granted
+                                : l10n.health_write_denied),
+                            backgroundColor: writeGranted
+                                ? theme.colorScheme.primary
+                                : theme.colorScheme.error,
+                            duration: const Duration(seconds: 2),
+                          ),
+                        );
+                      });
+                    },
+                    onOpenSettings: () => openAppSettings(),
+                    isRequired: false,
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Historical Health Data permission (optional)
+                  PermissionCard(
+                    icon: Icons.history,
+                    title: l10n.permission_health_historical_title,
+                    description: l10n.permission_health_historical_description,
+                    status: permissionsState.healthHistoricalPermissionStatus
+                        ? PermissionStatus.granted
+                        : PermissionStatus.denied,
+                    onRequestPermission: () {
+                      // Überprüfe zuerst, ob Read-Berechtigung vorhanden ist
+                      if (!permissionsState.healthPermissionStatus) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(
+                                'Bitte erteile zuerst die Leseberechtigung für Gesundheitsdaten'),
+                            backgroundColor: theme.colorScheme.error,
+                            duration: const Duration(seconds: 2),
+                          ),
+                        );
+                        return;
+                      }
+
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Row(
+                            children: [
+                              const SizedBox(
+                                width: 20,
+                                height: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: Colors.white,
+                                ),
+                              ),
+                              const SizedBox(width: 16),
+                              Text(l10n
+                                  .requesting_health_historical_permissions),
+                            ],
+                          ),
+                          duration: const Duration(seconds: 1),
+                        ),
+                      );
+
+                      // Request optional HISTORICAL-Permissions
+                      ref
+                          .read(permissionsProvider.notifier)
+                          .requestHealthHistoricalPermission()
+                          .then((_) {
+                        // Nach dem Anfordern den Status prüfen
+                        final historicalGranted = ref
+                            .read(permissionsProvider)
+                            .healthHistoricalPermissionStatus;
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(historicalGranted
+                                ? l10n.health_historical_granted
+                                : l10n.health_historical_denied),
+                            backgroundColor: historicalGranted
+                                ? theme.colorScheme.primary
+                                : theme.colorScheme.error,
+                            duration: const Duration(seconds: 2),
+                          ),
+                        );
+                      });
+                    },
+                    onOpenSettings: () => openAppSettings(),
+                    isRequired: false,
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Location permission
+                  PermissionCard(
+                    icon: Icons.location_on,
+                    title: l10n.permission_location_title,
+                    description: l10n.permission_location_description,
+                    status: permissionsState.locationPermissionStatus,
+                    onRequestPermission: () => ref
+                        .read(permissionsProvider.notifier)
+                        .requestLocationPermission(),
+                    onOpenSettings: () => openAppSettings(),
+                    isRequired: false,
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Activity recognition permission
+                  PermissionCard(
+                    icon: Icons.directions_walk,
+                    title: l10n.permission_activity_title,
+                    description: l10n.permission_activity_description,
+                    status: permissionsState.activityPermissionStatus,
+                    onRequestPermission: () => ref
+                        .read(permissionsProvider.notifier)
+                        .requestActivityPermission(),
+                    onOpenSettings: () => openAppSettings(),
+                    isRequired: false,
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Notification permission
+                  PermissionCard(
+                    icon: Icons.notifications,
+                    title: l10n.permission_notification_title,
+                    description: l10n.permission_notification_description,
+                    status: permissionsState.notificationPermissionStatus,
+                    onRequestPermission: () => ref
+                        .read(permissionsProvider.notifier)
+                        .requestNotificationPermission(),
+                    onOpenSettings: () => openAppSettings(),
+                    isRequired: false,
+                  ),
+
+                  const SizedBox(height: 24),
+
+                  // Hinweistext
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.surfaceContainerHighest
+                          .withValues(alpha: 0.5),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Column(
+                      children: [
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Icon(
+                              Icons.help_outline,
+                              color: theme.colorScheme.onSurfaceVariant,
+                              size: 18,
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                'Hinweis: Einige Berechtigungen können nur in den Systemeinstellungen deines Geräts geändert werden.',
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: theme.colorScheme.onSurfaceVariant,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
-        ),
-      ),
-    );
+        ));
   }
 }

--- a/lib/presentation/tracking/screen/tracking_screen.dart
+++ b/lib/presentation/tracking/screen/tracking_screen.dart
@@ -56,17 +56,24 @@ class TrackingScreen extends HookConsumerWidget {
                           t.name == trackingState.activity.activityType?.name)))
                   : Text(AppLocalizations.of(context)!.tracking_title),
             ),
-            body: trackingState.permissionsGranted
-                ? _buildTracking(
-                    context,
-                    trackingState,
-                    ref.read(trackingViewModelProvider.notifier).startTracking,
-                    ref.read(trackingViewModelProvider.notifier).stopTracking,
-                    ref
-                        .read(trackingViewModelProvider.notifier)
-                        .togglePauseTracking,
-                    ref.read(trackingViewModelProvider.notifier).startTimer)
-                : PermissionScreen()));
+            body: Container(
+                margin: EdgeInsets.only(
+                    bottom: MediaQuery.of(context).viewPadding.bottom),
+                child: trackingState.permissionsGranted
+                    ? _buildTracking(
+                        context,
+                        trackingState,
+                        ref
+                            .read(trackingViewModelProvider.notifier)
+                            .startTracking,
+                        ref
+                            .read(trackingViewModelProvider.notifier)
+                            .stopTracking,
+                        ref
+                            .read(trackingViewModelProvider.notifier)
+                            .togglePauseTracking,
+                        ref.read(trackingViewModelProvider.notifier).startTimer)
+                    : PermissionScreen())));
   }
 
   Widget _buildTracking(


### PR DESCRIPTION
# 🚀 Pull Request

## Brief Description
This pull request resolves an issue with missing margin bottom causing the system navigation to exclude content of the application. This is resolved by adding margin depending on the system navigation size

## Linked Issues
<!-- Link related issues with the format: Fixes #123, Resolves #456, Closes #1337 -->
- Fixes #119

## Screenshots
| Old screen | Now with bottom margin |
|---|---|
| ![433048990-68542080-2432-4c29-9f26-6ecae8043ca6](https://github.com/user-attachments/assets/1b933a61-7020-4d1c-89b6-6eff64c44028) | ![image](https://github.com/user-attachments/assets/af6022c5-da68-44f8-8772-bd0cc598d091) |


## GitHub Copilot Text
This pull request includes several changes to improve the layout and padding of various screens in the application. The main focus is on adding a bottom margin to containers to account for the device's view padding, ensuring a better user experience across different devices.

### Layout and Padding Improvements:

* [`lib/presentation/challenges/badgeLists/widgets/category_badges_section.dart`](diffhunk://#diff-7cb86e76ea9d287175f0495bae148a9b47d9e7d239c9e32cab8e2bcd006456ebL61-R64): Replaced `Padding` with `Container` and added a bottom margin to account for the device's view padding. [[1]](diffhunk://#diff-7cb86e76ea9d287175f0495bae148a9b47d9e7d239c9e32cab8e2bcd006456ebL61-R64) [[2]](diffhunk://#diff-7cb86e76ea9d287175f0495bae148a9b47d9e7d239c9e32cab8e2bcd006456ebL118-R122)
* [`lib/presentation/challenges/streak/screen/streak_details_screen.dart`](diffhunk://#diff-93e4375871ee12a01c76487f6446ff0380c7d5dfef43f4f553baeb12d68ea36eR73-R75): Wrapped the main column in a `Container` and added a bottom margin to account for the device's view padding. [[1]](diffhunk://#diff-93e4375871ee12a01c76487f6446ff0380c7d5dfef43f4f553baeb12d68ea36eR73-R75) [[2]](diffhunk://#diff-93e4375871ee12a01c76487f6446ff0380c7d5dfef43f4f553baeb12d68ea36eL97-R100)
* [`lib/presentation/profile/screen/permissions_settings_screen.dart`](diffhunk://#diff-90b689fa9760b9b500d20dba87b979e37ee2b6d7f8034db402842ca07274eeffL40-R43): Added a `Container` with a bottom margin to the body of the screen to account for the device's view padding. [[1]](diffhunk://#diff-90b689fa9760b9b500d20dba87b979e37ee2b6d7f8034db402842ca07274eeffL40-R43) [[2]](diffhunk://#diff-90b689fa9760b9b500d20dba87b979e37ee2b6d7f8034db402842ca07274eeffL347-R351)
* [`lib/presentation/tracking/screen/tracking_screen.dart`](diffhunk://#diff-65c8cba003d8683ee3ed041a1cbc880ced1ca24cd8ad4ea5bd32a1e1684c526dL59-R76): Added a `Container` with a bottom margin to the body of the screen to account for the device's view padding.

### Code Formatting Adjustments:

* [`lib/presentation/challenges/badgeLists/widgets/category_badges_section.dart`](diffhunk://#diff-7cb86e76ea9d287175f0495bae148a9b47d9e7d239c9e32cab8e2bcd006456ebL75-R79): Reformatted the style property of the `Text` widget for better readability.
* [`lib/presentation/profile/screen/permissions_settings_screen.dart`](diffhunk://#diff-90b689fa9760b9b500d20dba87b979e37ee2b6d7f8034db402842ca07274eeffL49-R53): Reformatted the `color` property of the `BoxDecoration` and the `Text` widget for better readability. [[1]](diffhunk://#diff-90b689fa9760b9b500d20dba87b979e37ee2b6d7f8034db402842ca07274eeffL49-R53) [[2]](diffhunk://#diff-90b689fa9760b9b500d20dba87b979e37ee2b6d7f8034db402842ca07274eeffL231-R235)