### PR TITLE
Fix pause/resume state handling in tracking view model

### DIFF
--- a/lib/presentation/tracking/view_model/tracking_view_model.dart
+++ b/lib/presentation/tracking/view_model/tracking_view_model.dart
@@ -138,12 +138,12 @@ class TrackingViewModel extends StateNotifier<TrackingState?> {
       case Event.pause:
         if (eventMessage.data != null) {
           state = state?.copyWith(
-              newActivity: eventMessage.data as Activity, newIsPaused: false);
+              newActivity: eventMessage.data as Activity, newIsPaused: true);
         }
       case Event.resume:
         if (eventMessage.data != null) {
           state = state?.copyWith(
-              newActivity: eventMessage.data as Activity, newIsPaused: true);
+              newActivity: eventMessage.data as Activity, newIsPaused: false);
           startTimer();
         }
       case Event.stop:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "3f5fa4d122126adbda9c6ea441ec149b9d0c621c"
+      resolved-ref: "7220ff53dd7fd926a3250001200dc308f5d97cf4"
       url: "https://github.com/Jozys/activity_tracking.git"
     source: git
     version: "0.0.1"


### PR DESCRIPTION
# 🚀 Pull Request

## Brief Description
This pull request resolves an issue with the tracking timer to be start twice. This was caused by a bug in the activity_tracking library and a wrong state update.

## Linked Issues
- Fixes #114 

## GitHub Copilot Text
This pull request includes a small but important change to the `TrackingViewModel` class in the `lib/presentation/tracking/view_model/tracking_view_model.dart` file. The change corrects the logic for handling `pause` and `resume` events by swapping the values of `newIsPaused`.

* [`lib/presentation/tracking/view_model/tracking_view_model.dart`](diffhunk://#diff-8b86724fcfb46b7847a39fbc659970af43ec876e4fda5cbbf6a9d6fb2562343cL141-R146): Corrected the `newIsPaused` value for `pause` and `resume` events to ensure the state is properly updated.