### PR TITLE
Fix/systembars paddings and colors

### DIFF
--- a/android/app/src/main/kotlin/de/buseslaar/movetopia/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/buseslaar/movetopia/MainActivity.kt
@@ -1,5 +1,14 @@
 package de.buseslaar.movetopia
 
+import android.os.Build
+import android.os.Bundle
 import io.flutter.embedding.android.FlutterFragmentActivity
 
-class MainActivity : FlutterFragmentActivity()
+class MainActivity : FlutterFragmentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.setDecorFitsSystemWindows(false)
+        }
+    }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,12 +76,6 @@ interface class MoveTopiaAppViewModel {
     log.info('Starting app initialization...');
 
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
-    SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
-      systemNavigationBarContrastEnforced: false,
-      statusBarColor: Colors.transparent,
-      systemNavigationBarColor: Colors.transparent,
-      systemStatusBarContrastEnforced: false,
-    ));
 
     try {
       await _initializeAppDates();
@@ -181,6 +175,18 @@ class MoveTopiaApp extends HookConsumerWidget {
     }
 
     theme = useDarkTheme ? darkTheme : lightTheme;
+
+    SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
+      statusBarColor: Colors.transparent,
+      systemNavigationBarColor: Colors.transparent,
+      statusBarIconBrightness:
+          useDarkTheme ? Brightness.light : Brightness.dark,
+      statusBarBrightness: useDarkTheme ? Brightness.dark : Brightness.light,
+      systemNavigationBarIconBrightness:
+          useDarkTheme ? Brightness.light : Brightness.dark,
+      systemNavigationBarContrastEnforced: false,
+      systemStatusBarContrastEnforced: false,
+    ));
 
     if (onboardingStatus is AsyncLoading) {
       return MaterialApp(

--- a/lib/presentation/challenges/streak/screen/streak_details_screen.dart
+++ b/lib/presentation/challenges/streak/screen/streak_details_screen.dart
@@ -21,11 +21,15 @@ class StreakDetailsScreen extends ConsumerWidget {
     // Key für den RefreshIndicator
     final refreshIndicatorKey = GlobalKey<RefreshIndicatorState>();
 
+    // Farbe für Header und AppBar
+    final headerColor =
+        Theme.of(context).colorScheme.primary.withValues(alpha: 0.1);
+
     return Scaffold(
       appBar: AppBar(
         title: Text(l10n.streakDetails),
-        backgroundColor:
-            Theme.of(context).colorScheme.primary.withValues(alpha: 0.1),
+        scrolledUnderElevation: 0.0,
+        backgroundColor: headerColor,
         elevation: 0,
         actions: [
           // Manueller Refresh-Button in der AppBar
@@ -47,6 +51,7 @@ class StreakDetailsScreen extends ConsumerWidget {
           l10n,
           ref,
           refreshIndicatorKey,
+          headerColor,
         ),
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (error, stack) => Center(
@@ -66,6 +71,7 @@ class StreakDetailsScreen extends ConsumerWidget {
     AppLocalizations l10n,
     WidgetRef ref,
     GlobalKey<RefreshIndicatorState> refreshIndicatorKey,
+    Color headerColor,
   ) {
     return RefreshIndicator(
       key: refreshIndicatorKey,
@@ -73,7 +79,7 @@ class StreakDetailsScreen extends ConsumerWidget {
       child: Column(
         children: [
           // Header mit Streak-Zähler
-          _buildHeader(context, streakCount, ref),
+          _buildHeader(context, streakCount, ref, headerColor),
 
           // Kalender
           Expanded(
@@ -97,13 +103,13 @@ class StreakDetailsScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildHeader(
-      BuildContext context, AsyncValue<int> streakCount, WidgetRef ref) {
+  Widget _buildHeader(BuildContext context, AsyncValue<int> streakCount,
+      WidgetRef ref, Color headerColor) {
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.1),
+        color: headerColor,
         borderRadius: const BorderRadius.only(
           bottomLeft: Radius.circular(24),
           bottomRight: Radius.circular(24),

--- a/lib/presentation/common/navigator.dart
+++ b/lib/presentation/common/navigator.dart
@@ -24,32 +24,62 @@ class MoveTopiaNavigator extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context)!;
+    final isRootRoute = _isRootRoute(context);
+
+    // Get system insets via MediaQuery
+    final mediaQuery = MediaQuery.of(context);
 
     return Scaffold(
-      body: navigationShell,
-      bottomNavigationBar: _isRootRoute(context)
-          ? NavigationBar(
-              selectedIndex: navigationShell.currentIndex,
-              onDestinationSelected: (int index) =>
-                  navigationShell.goBranch(index),
-              destinations: [
-                NavigationDestination(
-                  icon: const Icon(Icons.today),
-                  label: l10n.navigation_today,
-                ),
-                NavigationDestination(
-                  icon: const Icon(Icons.list),
-                  label: l10n.navigation_activities,
-                ),
-                NavigationDestination(
-                  icon: const Icon(Icons.emoji_events),
-                  label: l10n.navigation_challenges,
-                ),
-                NavigationDestination(
-                  icon: const Icon(Icons.person),
-                  label: l10n.navigation_profile,
-                ),
-              ],
+      // For screens with bottom navigation, we modify the body to handle insets differently
+      body: MediaQuery(
+        // Remove bottom padding from content area when showing navigation bar
+        // This ensures content in all screens is properly inset
+        data: isRootRoute
+            ? mediaQuery.copyWith(
+                padding: mediaQuery.padding.copyWith(bottom: 0),
+                viewPadding: mediaQuery.viewPadding.copyWith(bottom: 0),
+                viewInsets: mediaQuery.viewInsets,
+              )
+            : mediaQuery,
+        child: SafeArea(
+          // Only apply bottom padding on screens without bottom navigation
+          bottom: !isRootRoute,
+          child: navigationShell,
+        ),
+      ),
+      // Bottom navigation bar that extends behind system navigation
+      bottomNavigationBar: isRootRoute
+          ? NavigationBarTheme(
+              data: NavigationBarThemeData(
+                // Ensure the height is appropriate to prevent extra padding
+                height: 80,
+                indicatorColor:
+                    Theme.of(context).colorScheme.secondaryContainer,
+              ),
+              child: NavigationBar(
+                backgroundColor: Theme.of(context).colorScheme.surface,
+                selectedIndex: navigationShell.currentIndex,
+                onDestinationSelected: (int index) =>
+                    navigationShell.goBranch(index),
+                destinations: [
+                  NavigationDestination(
+                    icon: const Icon(Icons.today),
+                    label: l10n.navigation_today,
+                  ),
+                  NavigationDestination(
+                    icon: const Icon(Icons.list),
+                    label: l10n.navigation_activities,
+                  ),
+                  NavigationDestination(
+                    icon: const Icon(Icons.emoji_events),
+                    label: l10n.navigation_challenges,
+                  ),
+                  NavigationDestination(
+                    icon: const Icon(Icons.person),
+                    label: l10n.navigation_profile,
+                  ),
+                ],
+              ),
             )
           : null,
     );

--- a/lib/presentation/common/navigator.dart
+++ b/lib/presentation/common/navigator.dart
@@ -49,37 +49,29 @@ class MoveTopiaNavigator extends HookConsumerWidget {
       ),
       // Bottom navigation bar that extends behind system navigation
       bottomNavigationBar: isRootRoute
-          ? NavigationBarTheme(
-              data: NavigationBarThemeData(
-                // Ensure the height is appropriate to prevent extra padding
-                height: 80,
-                indicatorColor:
-                    Theme.of(context).colorScheme.secondaryContainer,
-              ),
-              child: NavigationBar(
-                backgroundColor: Theme.of(context).colorScheme.surface,
-                selectedIndex: navigationShell.currentIndex,
-                onDestinationSelected: (int index) =>
-                    navigationShell.goBranch(index),
-                destinations: [
-                  NavigationDestination(
-                    icon: const Icon(Icons.today),
-                    label: l10n.navigation_today,
-                  ),
-                  NavigationDestination(
-                    icon: const Icon(Icons.list),
-                    label: l10n.navigation_activities,
-                  ),
-                  NavigationDestination(
-                    icon: const Icon(Icons.emoji_events),
-                    label: l10n.navigation_challenges,
-                  ),
-                  NavigationDestination(
-                    icon: const Icon(Icons.person),
-                    label: l10n.navigation_profile,
-                  ),
-                ],
-              ),
+          ? NavigationBar(
+              height: 80,
+              selectedIndex: navigationShell.currentIndex,
+              onDestinationSelected: (int index) =>
+                  navigationShell.goBranch(index),
+              destinations: [
+                NavigationDestination(
+                  icon: const Icon(Icons.today),
+                  label: l10n.navigation_today,
+                ),
+                NavigationDestination(
+                  icon: const Icon(Icons.list),
+                  label: l10n.navigation_activities,
+                ),
+                NavigationDestination(
+                  icon: const Icon(Icons.emoji_events),
+                  label: l10n.navigation_challenges,
+                ),
+                NavigationDestination(
+                  icon: const Icon(Icons.person),
+                  label: l10n.navigation_profile,
+                ),
+              ],
             )
           : null,
     );


### PR DESCRIPTION
# 🚀 Pull Request

## Brief Description
This pull request resolves an issue with missing margin bottom causing the system navigation to exclude content of the application. This is resolved by adding window insets to all screens without navigation bar

## Linked Issues
<!-- Link related issues with the format: Fixes #123, Resolves #456, Closes #1337 -->
- Fixes #119

## Screenshots
|  |  |  |
|---|---|---|
| ![Screenshot_20250413_211028](https://github.com/user-attachments/assets/86653330-70f1-45de-b7da-77badeca5dda) | ![Screenshot_20250413_210958](https://github.com/user-attachments/assets/b19835ea-1740-4a4b-b703-c56f87c8dc13)|![Screenshot_20250413_210941](https://github.com/user-attachments/assets/b78ccb0c-801e-4af1-a0d9-d3b8289eb17a)|


## GitHub Copilot Text
This pull request includes changes to the Android and Flutter codebases to improve UI behavior and code organization. The most important changes include modifications to the `MainActivity` class to handle system window insets, refactoring of the `StreakDetailsScreen` to use a consistent header color, and updates to the `MoveTopiaNavigator` to properly handle system insets and navigation bar behavior.

### Android Changes:
* [`android/app/src/main/kotlin/de/buseslaar/movetopia/MainActivity.kt`](diffhunk://#diff-cf8e6b4263cf16813f43f9492f23ea0708525ce8f11e2a88f45f30a6f8a09c8fR3-R14): Updated `MainActivity` to override `onCreate` and set the window to not fit system windows for Android R and above.

### Flutter Changes:
* [`lib/presentation/challenges/streak/screen/streak_details_screen.dart`](diffhunk://#diff-93e4375871ee12a01c76487f6446ff0380c7d5dfef43f4f553baeb12d68ea36eR24-R32): Refactored `StreakDetailsScreen` to use a `headerColor` variable for the header and app bar background color, ensuring consistency across the UI. [[1]](diffhunk://#diff-93e4375871ee12a01c76487f6446ff0380c7d5dfef43f4f553baeb12d68ea36eR24-R32) [[2]](diffhunk://#diff-93e4375871ee12a01c76487f6446ff0380c7d5dfef43f4f553baeb12d68ea36eR54) [[3]](diffhunk://#diff-93e4375871ee12a01c76487f6446ff0380c7d5dfef43f4f553baeb12d68ea36eR74-R82) [[4]](diffhunk://#diff-93e4375871ee12a01c76487f6446ff0380c7d5dfef43f4f553baeb12d68ea36eL100-R112)
* [`lib/presentation/common/navigator.dart`](diffhunk://#diff-8b89b88db984ae0dffe9c50fa5e3a873c590d67d1aece2151d04694319870827R27-R60): Updated `MoveTopiaNavigator` to handle system insets properly and ensure the bottom navigation bar extends behind the system navigation, improving the layout for screens with bottom navigation. [[1]](diffhunk://#diff-8b89b88db984ae0dffe9c50fa5e3a873c590d67d1aece2151d04694319870827R27-R60) [[2]](diffhunk://#diff-8b89b88db984ae0dffe9c50fa5e3a873c590d67d1aece2151d04694319870827R82)