### PR TITLE
Hide Floating Action button on iOS

### DIFF
--- a/lib/presentation/activities/list/screen/activities_screen.dart
+++ b/lib/presentation/activities/list/screen/activities_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -66,11 +67,13 @@ class ActivitiesScreen extends HookConsumerWidget {
       body: activities.isLoading && activities.activities.isEmpty
           ? const Center(child: CircularProgressIndicator())
           : _buildBody(context, activities, fetchHealthData, scrollController),
-      floatingActionButton: FloatingActionButton(
-          child: const Icon(Icons.add),
-          onPressed: () {
-            context.push(trackingPath);
-          }),
+      floatingActionButton: Platform.isAndroid
+          ? FloatingActionButton(
+              child: const Icon(Icons.add),
+              onPressed: () {
+                context.push(trackingPath);
+              })
+          : null,
     );
   }
 }

--- a/lib/presentation/today/screen/today_screen.dart
+++ b/lib/presentation/today/screen/today_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -142,13 +143,14 @@ class TodayScreen extends HookConsumerWidget {
             pauseTracking,
             navigateToBadges,
             refreshIndicatorKey.value),
-        floatingActionButton: trackingState?.isRecording == false
-            ? FloatingActionButton(
-                child: const Icon(Icons.add),
-                onPressed: () {
-                  context.push(trackingPath);
-                })
-            : null);
+        floatingActionButton:
+            trackingState?.isRecording == false && Platform.isAndroid
+                ? FloatingActionButton(
+                    child: const Icon(Icons.add),
+                    onPressed: () {
+                      context.push(trackingPath);
+                    })
+                : null);
   }
 }
 


### PR DESCRIPTION
Short Summery: The FAB is not shown on iOS anymore due to limitations of the tracking library