### PR TITLE
Add long press functionality to copy app version

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -50,6 +50,7 @@
   "common_theme_dark": "Dunkler Modus",
   "common_about": "Über",
   "common_version": "Version",
+  "common_version_copied": "Version in die Zwischenablage kopiert",
   "common_error_version": "Fehler beim Laden der Version",
   "common_error": "Fehler {error}",
   "common_unknown": "Unbekannt",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -52,6 +52,7 @@
   "common_theme_dark": "Dark Mode",
   "common_about": "About",
   "common_version": "Version",
+  "common_version_copied": "Successfully copied version",
   "common_error_version": "Error loading version",
   "common_error": "Error {error}",
   "common_unknown": "Unknown",

--- a/lib/presentation/profile/screen/widgets/about_section.dart
+++ b/lib/presentation/profile/screen/widgets/about_section.dart
@@ -246,26 +246,22 @@ class VersionInfoTile extends StatelessWidget {
     Future<void> copyVersionToClipboard() async {
       final data = ClipboardData(text: packageInfo.version);
       await Clipboard.setData(data);
-      if (context.mounted) {
-        // Only show snackbar if Android API Level is higher than 31
+      if (!context.mounted) return;
+
+      // Determine if we should show a snackbar based on platform
+      // Don't show on Android 12+ (API 32+) as it has its own clipboard notification
+      if (Platform.isAndroid) {
         final deviceInfo = DeviceInfoPlugin();
-        var showSnackbar = true;
-        if (Platform.isAndroid) {
-          final androidInfo = await deviceInfo.androidInfo;
-          // Only show snackbar if Android API Level is higher than 31 meaning Android 12
-          showSnackbar = androidInfo.version.sdkInt < 32;
-        }
-        if (showSnackbar) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(l10n.common_version_copied)),
-          );
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(l10n.common_version_copied),
-            ),
-          );
+        final androidInfo = await deviceInfo.androidInfo;
+        if (androidInfo.version.sdkInt >= 32) {
+          return; // Android 12+ has native clipboard notifications
         }
       }
+
+      // Show snackbar on all other platforms and older Android versions
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.common_version_copied)),
+      );   
     }
 
     return InkWell(

--- a/lib/presentation/profile/screen/widgets/about_section.dart
+++ b/lib/presentation/profile/screen/widgets/about_section.dart
@@ -249,6 +249,14 @@ class VersionInfoTile extends StatelessWidget {
           context.go('$profilePath/$profileLoggingPath');
         }
       },
+      onLongPress: () {
+        Clipboard.setData(
+          ClipboardData(text: packageInfo.version),
+        );
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.common_version_copied)),
+        );
+      },
       child: Container(
         width: double.infinity,
         padding: const EdgeInsets.symmetric(vertical: 8.0),

--- a/lib/presentation/profile/screen/widgets/about_section.dart
+++ b/lib/presentation/profile/screen/widgets/about_section.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -240,6 +243,31 @@ class VersionInfoTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
 
+    Future<void> copyVersionToClipboard() async {
+      final data = ClipboardData(text: packageInfo.version);
+      await Clipboard.setData(data);
+      if (context.mounted) {
+        // Only show snackbar if Android API Level is higher than 31
+        final deviceInfo = DeviceInfoPlugin();
+        var showSnackbar = true;
+        if (Platform.isAndroid) {
+          final androidInfo = await deviceInfo.androidInfo;
+          // Only show snackbar if Android API Level is higher than 31 meaning Android 12
+          showSnackbar = androidInfo.version.sdkInt < 32;
+        }
+        if (showSnackbar) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(l10n.common_version_copied)),
+          );
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(l10n.common_version_copied),
+            ),
+          );
+        }
+      }
+    }
+
     return InkWell(
       onTap: () {
         hiddenLogAccessNotifier.incrementClickCount();
@@ -250,12 +278,7 @@ class VersionInfoTile extends StatelessWidget {
         }
       },
       onLongPress: () {
-        Clipboard.setData(
-          ClipboardData(text: packageInfo.version),
-        );
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.common_version_copied)),
-        );
+        copyVersionToClipboard();
       },
       child: Container(
         width: double.infinity,


### PR DESCRIPTION
# 🚀 Pull Request

## Brief Description
This pull request introduces a long press event on the version number of the application to copy that version number for a better bug reporting experience

## Linked Issues

- Closes #118 

## GitHub Copilot Text
This pull request focuses on enhancing the user experience by adding a feature to copy the app version to the clipboard and providing appropriate feedback. The most important changes include updates to localization files and the addition of a long press event in the `VersionInfoTile` widget.

Localization updates:

* [`lib/l10n/app_de.arb`](diffhunk://#diff-36252c65ab82cbff4774b4983cb9027a2bef4cb738d5ea656c0b903939b3871aR53): Added a new localization string for the message displayed when the version is copied to the clipboard.
* [`lib/l10n/app_en.arb`](diffhunk://#diff-9796fde3771f42a3a759ccc941731d83f96037a661e47dde27ce81d3447a69c2R55): Added a new localization string for the message displayed when the version is copied to the clipboard.

UI enhancements:

* [`lib/presentation/profile/screen/widgets/about_section.dart`](diffhunk://#diff-197e39590bc20cb68315c71e72ce18ac8769752a8152dbab25ab51384a8d2839R252-R259): Added a long press event to the `VersionInfoTile` widget to copy the app version to the clipboard and display a snackbar message confirming the action.