### PR TITLE
Fix Android Permissions and add Beta Tests to Readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ app.*.map.json
 /android/fastlane/report.xml
 /lib/version.dart
 /.env
+**/*.report.xml

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 [![Development Build](https://github.com/ScreepCode/MoveTopia/actions/workflows/build-dev-release.yml/badge.svg?branch=development)](https://github.com/ScreepCode/MoveTopia/actions/workflows/build-dev-release.yml)
 [![Flutter: v3.29.2](https://img.shields.io/badge/Flutter-v3.29.2-blue.svg)](https://flutter.dev)
 
-MoveTopia - your fitness companion for a healthier lifestyle! Track your daily activities, set goals, and stay motivated with MoveTopia. Our app turns fitness into an exciting adventure where you can earn badges, build streaks, and visualize your progress on the journey to a more active life.
+MoveTopia - your fitness companion for a healthier lifestyle! Track your daily activities, set
+goals, and stay motivated with MoveTopia. Our app turns fitness into an exciting adventure where you
+can earn badges, build streaks, and visualize your progress on the journey to a more active life.
 
 <a href='https://play.google.com/store/apps/details?id=de.buseslaar.movetopia'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png' width="200"/></a>
 
@@ -14,13 +16,33 @@ MoveTopia - your fitness companion for a healthier lifestyle! Track your daily a
 - **Statistics & Analytics**: Get detailed insights into your activities and progress
 - **Challenges & Awards**: Complete challenges, earn badges and collect experience points
 - **Motivating Streaks**: Build daily streaks of success and visualize them in the calendar
-- **Privacy-Focused**: All health data stays on your device - full control over your personal information
+- **Privacy-Focused**: All health data stays on your device - full control over your personal
+  information
 
 ## Beta Testing
 
 Join our beta testing program to get early access to new features:
 
-<a href='https://groups.google.com/g/movetopia-beta'><img alt='Join Beta Testing' src='https://img.shields.io/badge/Join-Beta_Testing-orange?style=for-the-badge&logo=google' height="30"/></a>
+<div align="center">
+  <table>
+    <tr>
+      <td align="center"><b>Android Beta</b></td>
+      <td align="center"><b>iOS TestFlight</b></td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://groups.google.com/g/movetopia-beta">
+          <img alt="Get it on Google Play Beta" src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" width="180"/>
+        </a>
+      </td>
+      <td>
+        <a target='_blank' href="https://testflight.apple.com/join/1MYANqEt" title="MoveTopia on TestFly">
+            <img width='200' src="https://beatscratch.io/assets/testflight-badge.png" alt="TestFly">
+        </a>
+      </td>
+    </tr>
+  </table>
+</div>
 
 For more information about the app and its features, visit our [website](https://movetopia.de).
 
@@ -55,7 +77,6 @@ flutter run
 
 ## Versioning
 MoveTopia uses a date-based versioning system in the format `YYYY.MM.DD+HOTFIX`.
-
 
 Thanks to all our contributors who help make MoveTopia better every day!
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Join our beta testing program to get early access to new features:
         </a>
       </td>
       <td>
-        <a target='_blank' href="https://testflight.apple.com/join/1MYANqEt" title="MoveTopia on TestFly">
+        <a target='_blank' href="https://testflight.apple.com/join/1MYANqEt" title="MoveTopia on TestFlight">
             <img width='200' src="https://beatscratch.io/assets/testflight-badge.png" alt="TestFly">
         </a>
       </td>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,6 +22,8 @@
     <uses-permission android:name="android.permission.READ_PRIVILEGED_PHONE_STATE" />
     <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_HISTORY" />
     <uses-permission android:name="android.permission.MANAGE_HEALTH_DATA" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:name="${applicationName}"

--- a/android/fastlane/README.md
+++ b/android/fastlane/README.md
@@ -69,7 +69,7 @@ Build debug APK with versioning
 [bundle exec] fastlane android build_release
 ```
 
-Build release APK without creating a release or tag
+Build release APK with versioning
 
 ### android assemble_release
 

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -32,3 +32,8 @@ Runner/GeneratedPluginRegistrant.*
 !default.mode2v3
 !default.pbxuser
 !default.perspectivev3
+/build/.last_build_id
+/.bundle/
+/vendor/
+/*.ipa
+/*.zip

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -23,6 +23,9 @@ PODS:
     - FlutterMacOS
   - url_launcher_ios (0.0.1):
     - Flutter
+  - webview_flutter_wkwebview (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - activity_tracking (from `.symlinks/plugins/activity_tracking/ios`)
@@ -36,6 +39,7 @@ DEPENDENCIES:
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
+  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
 EXTERNAL SOURCES:
   activity_tracking:
@@ -60,6 +64,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
+  webview_flutter_wkwebview:
+    :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
   activity_tracking: 8e15f16c8afa12f7fbef1988678dbd87e6841b57
@@ -73,6 +79,7 @@ SPEC CHECKSUMS:
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
 
 PODFILE CHECKSUM: 9ced0a3e1049d68a4eb33b5c7e1e2b0678b917a6
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2025.04.13</string>
+	<string>2025.04.24</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2025041300</string>
+	<string>2025042401</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSHealthShareUsageDescription</key>


### PR DESCRIPTION
# 🚀 Pull Request

## Brief Description
<!-- Briefly describe what these changes accomplish -->
- Fix Android Permissions 
- add Beta Tests to Readme

## GitHub Copilot Text
<!-- GitHub Copilot can suggest a PR description here -->
This pull request includes updates to the `README.md` file, enhancements to Android and iOS configurations, and adjustments to versioning and build processes. The most important changes are grouped into documentation updates, Android permissions, iOS configuration, and build system improvements.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R9): Improved formatting for the app description and privacy-focused feature, added a table layout for beta testing links, and removed an unnecessary blank line under the "Versioning" section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R45) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59)

### Android Permissions:
* [`android/app/src/main/AndroidManifest.xml`](diffhunk://#diff-63272c98a6330850888e633b43ba4c9decee6431a115e0d2731564838eaa1d1dR25-R26): Added `INTERNET` and `ACCESS_NETWORK_STATE` permissions to support network-related functionality.

### Build System Improvements:
* [`android/fastlane/README.md`](diffhunk://#diff-cb687d915c1f3341aa84abc8858370c833f2eab0bc71c59f5ca0a3b20fd29f1eL72-R72): Clarified the description of the `assemble_release` command to indicate it builds a release APK with versioning.
* [`ios/.gitignore`](diffhunk://#diff-ad68feae7b87d03ff24a0e3db65613c5399460565b8f8696d91573c832694075R35-R39): Added entries to ignore build artifacts (`.last_build_id`, `.bundle/`, `vendor/`, `*.ipa`, `*.zip`).