### PR TITLE
🔧 Add ProGuard rules for reflection, WebView, and url_launcher support

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,40 @@
+# Keep classes used for reflection
+-keepclassmembers class * {
+    <methods>;
+}
+
+# Keep url_launcher package
+-keep class androidx.core.content.FileProvider
+-keep class androidx.core.app.ActivityCompat
+-keep class androidx.core.content.ContextCompat
+
+# Keep url_launcher classes
+-keep class io.flutter.plugins.urllauncher.** { *; }
+-keep class androidx.core.content.** { *; }
+-keepattributes *Annotation*
+-keepclassmembers class * {
+    @android.webkit.JavascriptInterface <methods>;
+}
+
+# Keep all implementations of b2.a
+-keep class b2.a { *; }
+-keep class b2.** { *; }
+-keep class j2.d { *; }
+
+# WebView rules
+-keep class io.flutter.plugins.webviewflutter.** { *; }
+-keep class android.webkit.** { *; }
+-keep class * extends android.webkit.WebChromeClient { *; }
+-keep class * extends android.webkit.WebViewClient { *; }
+-keepclassmembers class * extends android.webkit.WebViewClient {
+    <methods>;
+}
+
+# Keep javascript interfaces
+-keepattributes JavascriptInterface
+-keep class * extends android.webkit.WebView { *; }
+
+# Keep all classes that might be used in WebView JS interface
+-keepclassmembers class * {
+    @android.webkit.JavascriptInterface <methods>;
+}


### PR DESCRIPTION
This pull request updates the ProGuard rules in the `android/app/proguard-rules.pro` file to ensure proper functionality of reflection, URL launcher, WebView, and JavaScript interfaces in the Android app. The changes primarily focus on preserving specific classes and methods from being removed or obfuscated during the build process.

### ProGuard Rule Updates:

* **Reflection Support**: Added rules to keep all class members used for reflection to prevent runtime issues. (`[android/app/proguard-rules.proR1-R40](diffhunk://#diff-09b2c99413460ebb90ea73560bea82a46996111028b6fbab31316433e58d42a8R1-R40)`)
* **URL Launcher**: Preserved classes related to the `url_launcher` package, including `androidx.core` and `io.flutter.plugins.urllauncher` classes, to ensure proper functionality. (`[android/app/proguard-rules.proR1-R40](diffhunk://#diff-09b2c99413460ebb90ea73560bea82a46996111028b6fbab31316433e58d42a8R1-R40)`)
* **WebView and JavaScript Interfaces**: Added rules to keep WebView-related classes, JavaScript interfaces, and their methods, ensuring compatibility with WebView and JavaScript interactions. (`[android/app/proguard-rules.proR1-R40](diffhunk://#diff-09b2c99413460ebb90ea73560bea82a46996111028b6fbab31316433e58d42a8R1-R40)`)
* **Custom Implementations**: Preserved all implementations of `b2.a`, `b2.**`, and `j2.d` to maintain compatibility with custom logic. (`[android/app/proguard-rules.proR1-R40](diffhunk://#diff-09b2c99413460ebb90ea73560bea82a46996111028b6fbab31316433e58d42a8R1-R40)`)