### PR TITLE
Fix/activities screen

### DIFF
--- a/lib/presentation/activities/list/screen/activities_screen.dart
+++ b/lib/presentation/activities/list/screen/activities_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:io' show Platform;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -141,51 +142,67 @@ Widget _buildGroupedActivities(
     return seconds ~/ 60;
   }
 
-  return ListView.builder(
-    controller: scrollController,
-    physics: const ScrollPhysics(),
-    itemCount: activities?.length ?? 0,
-    itemBuilder: (context, index) {
-      final date = activities?.keys.elementAt(index);
-      final activityList = activities?[date]! ?? [];
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (date != null && activityList.isNotEmpty)
-            Padding(
-              padding:
-                  const EdgeInsets.only(top: 16.0, left: 16.0, right: 16.0),
-              child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Text(
-                      DateFormat("dd. MMMM yyyy").format(date),
-                      style: const TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                    Text(
-                      getDuration(getActivityMinutes(activityList), context),
-                      style: const TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                  ]),
-            ),
-          const Divider(),
-          ...activityList.map(
-            (activity) => _buildActivityItem(context, activity),
+  return LayoutBuilder(
+    builder: (context, constraints) {
+      return SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        controller: scrollController,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            minHeight: constraints.maxHeight,
           ),
-          // Add a loading indicator at the end of the list,
-          if (index == activities!.length - 1 && isLoading)
-            const Padding(
-              padding: EdgeInsets.symmetric(vertical: 8.0),
-              child: Center(child: CircularProgressIndicator()),
-            ) // Show loading
-          // Show no more entries text if end is reached
-          else if (index == activities.length - 1 && !isLoading)
-            const Padding(
-                padding: EdgeInsets.all(16.0),
-                child: Center(
-                  child: Text("No more entries"),
-                )),
-        ],
+          child: ListView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: activities?.length ?? 0,
+            itemBuilder: (context, index) {
+              final date = activities?.keys.elementAt(index);
+              final activityList = activities?[date]! ?? [];
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (date != null && activityList.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(
+                          top: 16.0, left: 16.0, right: 16.0),
+                      child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              DateFormat("dd. MMMM yyyy").format(date),
+                              style:
+                                  const TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text(
+                              getDuration(
+                                  getActivityMinutes(activityList), context),
+                              style:
+                                  const TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                          ]),
+                    ),
+                  const Divider(),
+                  ...activityList.map(
+                    (activity) => _buildActivityItem(context, activity),
+                  ),
+                  // Add a loading indicator at the end of the list,
+                  if (index == activities!.length - 1 && isLoading)
+                    const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 8.0),
+                      child: Center(child: CircularProgressIndicator()),
+                    ) // Show loading
+                  // Show no more entries text if end is reached
+                  else if (index == activities.length - 1 && !isLoading)
+                    const Padding(
+                        padding: EdgeInsets.all(16.0),
+                        child: Center(
+                          child: Text("No more entries"),
+                        )),
+                ],
+              );
+            },
+          ),
+        ),
       );
     },
   );

--- a/lib/presentation/activities/list/view_model/activities_view_model.dart
+++ b/lib/presentation/activities/list/view_model/activities_view_model.dart
@@ -53,6 +53,7 @@ class ActivitiesViewModel extends StateNotifier<ActivitiesState> {
 
       for (int i = 0; i < workouts.length; i++) {
         ActivityPreview workout = workouts[i];
+
         state.icons ??= {};
         if (state.icons!.containsKey(workout.sourceId)) {
           workouts[i].icon = state.icons?[workout.sourceId];
@@ -63,8 +64,10 @@ class ActivitiesViewModel extends StateNotifier<ActivitiesState> {
           state.icons![workout.sourceId] = workouts[i].icon;
           state = state.copyWith(newIcons: state.icons);
         }
+        // Convert the start date to local time
+        final startDateLocal = toLocal(workout.start);
         DateTime day = DateTime(
-            workout.start.year, workout.start.month, workout.start.day);
+            startDateLocal.year, startDateLocal.month, startDateLocal.day);
         if (workoutsByDay[day] == null) {
           workoutsByDay[day] = [];
         }


### PR DESCRIPTION
# 🚀 Pull Request

## Brief Description
This pull request resolves two bugs:
1. A workout in utc time would be grouped to the wrong day if the MESZ time would be within 0.00 and 2.00 because the utc time is then on the previous day.
2. The refresh indicator would not work if the list view in the activities screen does not cover the whole screen size.

## GitHub Copilot Text
<!-- GitHub Copilot can suggest a PR description here -->
This pull request introduces several changes to improve the user interface and data handling in the activities screen and view model. The most significant updates include refactoring the layout of the grouped activities list for better scrolling behavior and ensuring workout start dates are converted to local time for accurate grouping.

### UI Improvements:
* Refactored `_buildGroupedActivities` in `activities_screen.dart` to wrap the `ListView.builder` in a `LayoutBuilder`, `SingleChildScrollView`, and `ConstrainedBox` for better handling of scrolling and layout constraints. This ensures the list always fills the available space and supports pull-to-refresh behavior. [[1]](diffhunk://#diff-88f7691689bff6b9ae5559a39398280e2b845d3fe6c13d6a14e5387fb374e83cL144-R156) [[2]](diffhunk://#diff-88f7691689bff6b9ae5559a39398280e2b845d3fe6c13d6a14e5387fb374e83cR204-R207)

### Code Formatting:
* Adjusted formatting in `_buildGroupedActivities` to improve code readability, particularly around `Padding` and `Text` widget properties.

### Data Handling:
* Updated `ActivitiesViewModel` in `activities_view_model.dart` to convert workout start dates to local time before grouping them by day. This ensures accurate grouping of activities based on the user's local timezone.

### Minor Changes:
* Added a blank line in the loop processing workouts in `ActivitiesViewModel` for better code organization.
* Added a blank line after an import statement in `activities_screen.dart` for consistency.