### PR TITLE
Center tab alignment in badge lists screen

### DIFF
--- a/lib/presentation/challenges/badgeLists/screen/badge_lists_screen.dart
+++ b/lib/presentation/challenges/badgeLists/screen/badge_lists_screen.dart
@@ -138,6 +138,7 @@ class _BadgeTabsView extends StatelessWidget {
         children: [
           TabBar(
             isScrollable: true,
+            tabAlignment: TabAlignment.center,
             tabs: categories
                 .map((category) => Tab(text: _getCategoryName(category, l10n)))
                 .toList(),


### PR DESCRIPTION
# 🚀 Pull Request

## Brief Description
This pull requests resolves missing center alignment for the tabs inside the Badge Screen

## Linked Issues
<!-- Link related issues with the format: Fixes #123, Resolves #456, Closes #1337 -->
- Fixes #137 

## Screenshots
<!-- Add screenshots if UI changes were made. Either new screens only or before/after -->
| Old | New  |
|----------|----------|
|![image](https://github.com/user-attachments/assets/230bcd2e-3694-4425-baa4-34c03b97863e)| ![image](https://github.com/user-attachments/assets/56bceab3-1e22-41c2-b140-2e68116d4d48)   |

## GitHub Copilot Text
This pull request introduces a small change to the `BadgeTabsView` class in the `badge_lists_screen.dart` file. The change adds a new property, `tabAlignment`, to the `TabBar` widget, setting it to `TabAlignment.center` to ensure the tabs are centrally aligned.