### PR TITLE
Check whether historical health functionality is available

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -338,6 +338,7 @@
   "permission_health_read_description": "Zum Lesen deiner Aktivitäten und Fitness-Daten",
   "permission_health_write_title": "Gesundheitsdaten Schreiben",
   "permission_health_write_description": "Zum Speichern deiner Aktivitäten in der Health-Datenbank",
+  "permission_health_read_missing": "Bitte erteile zuerst die Leseberechtigung für Gesundheitsdaten",
   "permission_health_historical_title": "Historische Gesundheitsdaten",
   "permission_health_historical_description": "Für den Zugriff auf Gesundheitsdaten, die älter als 30 Tage sind, für Langzeitanalysen",
   "permission_allow": "Erlauben",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -357,6 +357,7 @@
   "permission_health_read_description": "To read your activities and fitness data",
   "permission_health_write_title": "Health Data Write",
   "permission_health_write_description": "To save your activities to the health database",
+  "permission_health_read_missing": "Please first allow access to read your health data",
   "permission_health_historical_title": "Historical Health Data",
   "permission_health_historical_description": "To access your health data older than 30 days for long-term analysis",
   "permission_allow": "Allow",

--- a/lib/presentation/onboarding/providers/permissions_provider.dart
+++ b/lib/presentation/onboarding/providers/permissions_provider.dart
@@ -19,6 +19,12 @@ class PermissionsState {
   final bool healthWritePermissionStatus;
   final bool healthHistoricalPermissionStatus;
 
+  /*
+  * Determine if historical health functionality is available
+  * Only relevant for Android, on iOS this is always false
+  * */
+  final bool isHealthHistoricalAvailable;
+
   bool get hasRequiredPermissions => healthPermissionStatus;
 
   PermissionsState({
@@ -28,6 +34,7 @@ class PermissionsState {
     this.healthPermissionStatus = false,
     this.healthWritePermissionStatus = false,
     this.healthHistoricalPermissionStatus = false,
+    this.isHealthHistoricalAvailable = false,
   });
 
   PermissionsState copyWith({
@@ -37,6 +44,7 @@ class PermissionsState {
     bool? healthPermissionStatus,
     bool? healthWritePermissionStatus,
     bool? healthHistoricalPermissionStatus,
+    bool? isHealthHistoricalAvailable,
   }) {
     return PermissionsState(
       locationPermissionStatus:
@@ -51,6 +59,8 @@ class PermissionsState {
           healthWritePermissionStatus ?? this.healthWritePermissionStatus,
       healthHistoricalPermissionStatus: healthHistoricalPermissionStatus ??
           this.healthHistoricalPermissionStatus,
+      isHealthHistoricalAvailable:
+          isHealthHistoricalAvailable ?? this.isHealthHistoricalAvailable,
     );
   }
 
@@ -284,7 +294,20 @@ class PermissionsNotifier extends StateNotifier<PermissionsState> {
       }
 
       try {
-        // Verwende die direkte API-Methode, um zu prüfen, ob historische Berechtigungen gewährt wurden
+        // Überprüfe die Verfügbarkeit historischer Berechtigungen
+        // Dies ist nur für Android relevant, auf iOS ist dies nicht verfügbar
+
+        bool isHistoricalAvailable =
+            await _health.isHealthDataHistoryAvailable();
+        state =
+            state.copyWith(isHealthHistoricalAvailable: isHistoricalAvailable);
+        if (!isHistoricalAvailable) {
+          log.warning("Historical Health feature is not available");
+          return;
+        }
+
+        // Verwende die direkte API-Methode, um zu prüfen, ob historische Berechtigungen gewährt wurde
+
         bool hasHistoricalPermissions =
             await _health.isHealthDataHistoryAuthorized();
 

--- a/lib/presentation/onboarding/providers/permissions_provider.dart
+++ b/lib/presentation/onboarding/providers/permissions_provider.dart
@@ -294,8 +294,8 @@ class PermissionsNotifier extends StateNotifier<PermissionsState> {
       }
 
       try {
-        // Überprüfe die Verfügbarkeit historischer Berechtigungen
-        // Dies ist nur für Android relevant, auf iOS ist dies nicht verfügbar
+        // Check the availability of historical permissions
+        // This is only relevant for Android, on iOS this is not available
 
         bool isHistoricalAvailable =
             await _health.isHealthDataHistoryAvailable();

--- a/lib/presentation/onboarding/widgets/permissions_page.dart
+++ b/lib/presentation/onboarding/widgets/permissions_page.dart
@@ -144,8 +144,7 @@ class PermissionsPage extends ConsumerWidget {
                 if (!permissionsState.healthPermissionStatus) {
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(
-                      content: Text(
-                          'Bitte erteile zuerst die Leseberechtigung für Gesundheitsdaten'),
+                      content: Text(l10n.permission_health_read_missing),
                       backgroundColor: theme.colorScheme.error,
                       duration: const Duration(seconds: 2),
                     ),
@@ -200,8 +199,8 @@ class PermissionsPage extends ConsumerWidget {
 
             const SizedBox(height: 16),
 
-            // Historical Health Data permission - only for Android
-            if (Theme.of(context).platform == TargetPlatform.android)
+            // Historical Health Data permission - only if available
+            if (permissionsState.isHealthHistoricalAvailable)
               Column(
                 children: [
                   PermissionCard(
@@ -216,8 +215,7 @@ class PermissionsPage extends ConsumerWidget {
                       if (!permissionsState.healthPermissionStatus) {
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
-                            content: const Text(
-                                'Bitte erteile zuerst die Leseberechtigung für Gesundheitsdaten'),
+                            content: Text(l10n.permission_health_read_missing),
                             backgroundColor: theme.colorScheme.error,
                             duration: const Duration(seconds: 2),
                           ),

--- a/lib/presentation/profile/screen/permissions_settings_screen.dart
+++ b/lib/presentation/profile/screen/permissions_settings_screen.dart
@@ -136,8 +136,7 @@ class PermissionsSettingsScreen extends HookConsumerWidget {
                   if (!permissionsState.healthPermissionStatus) {
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
-                        content: Text(
-                            'Bitte erteile zuerst die Leseberechtigung für Gesundheitsdaten'),
+                        content: Text(l10n.permission_health_read_missing),
                         backgroundColor: theme.colorScheme.error,
                         duration: const Duration(seconds: 2),
                       ),
@@ -193,8 +192,8 @@ class PermissionsSettingsScreen extends HookConsumerWidget {
 
               const SizedBox(height: 16),
 
-              // Historical Health Data permission - only for Android
-              if (Theme.of(context).platform == TargetPlatform.android)
+              // Historical Health Data permission - only if available
+              if (permissionsState.isHealthHistoricalAvailable)
                 PermissionCard(
                   icon: Icons.history,
                   title: l10n.permission_health_historical_title,
@@ -207,8 +206,7 @@ class PermissionsSettingsScreen extends HookConsumerWidget {
                     if (!permissionsState.healthPermissionStatus) {
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
-                          content: Text(
-                              'Bitte erteile zuerst die Leseberechtigung für Gesundheitsdaten'),
+                          content: Text(l10n.permission_health_read_missing),
                           backgroundColor: theme.colorScheme.error,
                           duration: const Duration(seconds: 2),
                         ),


### PR DESCRIPTION
# 🚀 Pull Request

## Brief Description
This pull request hide the corresponding PermissionCard in case of Health Connect historical health functionality is not available. Apart from that it also localizes missing read permission.

## Linked Issues
<!-- Link related issues with the format: Fixes #123, Resolves #456, Closes #1337 -->
- Partly solves #139 

## GitHub Copilot Text
This pull request introduces support for checking the availability of historical health data permissions, refactors error messages to use localized strings, and updates the UI logic to conditionally display historical health data options based on availability. Below are the key changes grouped by theme:

### Localization Updates:
* Added a new localized string `permission_health_read_missing` to both `lib/l10n/app_de.arb` and `lib/l10n/app_en.arb` for displaying a message when health data read permissions are missing. [[1]](diffhunk://#diff-36252c65ab82cbff4774b4983cb9027a2bef4cb738d5ea656c0b903939b3871aR341) [[2]](diffhunk://#diff-9796fde3771f42a3a759ccc941731d83f96037a661e47dde27ce81d3447a69c2R360)

### Permissions State Enhancements:
* Introduced a new property `isHealthHistoricalAvailable` in the `PermissionsState` class to track the availability of historical health data functionality. Updated the constructor, `copyWith` method, and `PermissionsNotifier` logic to handle this property. [[1]](diffhunk://#diff-8a4214800464620d2099bc7cfa9c805f54af891b727a07e2d6b5ff7f71f66bacR22-R27) [[2]](diffhunk://#diff-8a4214800464620d2099bc7cfa9c805f54af891b727a07e2d6b5ff7f71f66bacR37) [[3]](diffhunk://#diff-8a4214800464620d2099bc7cfa9c805f54af891b727a07e2d6b5ff7f71f66bacR47) [[4]](diffhunk://#diff-8a4214800464620d2099bc7cfa9c805f54af891b727a07e2d6b5ff7f71f66bacR62-R63) [[5]](diffhunk://#diff-8a4214800464620d2099bc7cfa9c805f54af891b727a07e2d6b5ff7f71f66bacL287-R310)

### UI Logic Adjustments:
* Updated the `PermissionsPage` and `PermissionsSettingsScreen` widgets to use the new `isHealthHistoricalAvailable` property instead of relying solely on the platform check. This ensures the historical health data option is displayed only when available. [[1]](diffhunk://#diff-ed114b585bef8ee4333df6f2e72f1c9dfa98c882124fb226aad2ea091e172338L203-R203) [[2]](diffhunk://#diff-ed114b585bef8ee4333df6f2e72f1c9dfa98c882124fb226aad2ea091e172338L219-R218) [[3]](diffhunk://#diff-90b689fa9760b9b500d20dba87b979e37ee2b6d7f8034db402842ca07274eeffL196-R196) [[4]](diffhunk://#diff-90b689fa9760b9b500d20dba87b979e37ee2b6d7f8034db402842ca07274eeffL210-R209)

### Error Message Refactoring:
* Replaced hardcoded error messages for missing health data read permissions with the localized `permission_health_read_missing` string across multiple widgets for consistency. [[1]](diffhunk://#diff-ed114b585bef8ee4333df6f2e72f1c9dfa98c882124fb226aad2ea091e172338L147-R147) [[2]](diffhunk://#diff-ed114b585bef8ee4333df6f2e72f1c9dfa98c882124fb226aad2ea091e172338L219-R218) [[3]](diffhunk://#diff-90b689fa9760b9b500d20dba87b979e37ee2b6d7f8034db402842ca07274eeffL139-R139) [[4]](diffhunk://#diff-90b689fa9760b9b500d20dba87b979e37ee2b6d7f8034db402842ca07274eeffL210-R209)