### PR TITLE
Remove activities app icons

### DIFF
--- a/lib/utils/system_utils.dart
+++ b/lib/utils/system_utils.dart
@@ -1,22 +1,15 @@
 import 'dart:typed_data';
 
-import 'package:logging/logging.dart';
-
 Future<Uint8List?> getInstalledAppIcon(String sourceId) async {
-  final log = Logger("InstalledAppIcon");
   if (sourceId.isNotEmpty) {
-    try {
-      // Sadly due to the QUERY_ALL_PACKAGES permission not being allowed for release in the Play Store in this use case, this
-      // method is not usable in production. Therefore we have to disable it for now.
-      // TODO: Find a way to get the app icon without using QUERY_ALL_PACKAGES
-      // var appIcon =
-      //     (await InstalledApps.getAppInfo(sourceId.toString(), null))?.icon;
-      // if (appIcon != null && appIcon.isNotEmpty) {
-      //   return appIcon;
-      // }
-    } catch (_) {
-      log.info("App icon fetching failed");
-    }
+    // Sadly due to the QUERY_ALL_PACKAGES permission not being allowed for release in the Play Store in this use case, this
+    // method is not usable in production. Therefore we have to disable it for now.
+    // TODO: Find a way to get the app icon without using QUERY_ALL_PACKAGES
+    // var appIcon =
+    //     (await InstalledApps.getAppInfo(sourceId.toString(), null))?.icon;
+    // if (appIcon != null && appIcon.isNotEmpty) {
+    //   return appIcon;
+    // }
   }
   return null;
 }

--- a/lib/utils/system_utils.dart
+++ b/lib/utils/system_utils.dart
@@ -1,17 +1,19 @@
 import 'dart:typed_data';
 
-import 'package:installed_apps/installed_apps.dart';
 import 'package:logging/logging.dart';
 
 Future<Uint8List?> getInstalledAppIcon(String sourceId) async {
   final log = Logger("InstalledAppIcon");
   if (sourceId.isNotEmpty) {
     try {
-      var appIcon =
-          (await InstalledApps.getAppInfo(sourceId.toString(), null))?.icon;
-      if (appIcon != null && appIcon.isNotEmpty) {
-        return appIcon;
-      }
+      // Sadly due to the QUERY_ALL_PACKAGES permission not being allowed for release in the Play Store in this use case, this
+      // method is not usable in production. Therefore we have to disable it for now.
+      // TODO: Find a way to get the app icon without using QUERY_ALL_PACKAGES
+      // var appIcon =
+      //     (await InstalledApps.getAppInfo(sourceId.toString(), null))?.icon;
+      // if (appIcon != null && appIcon.isNotEmpty) {
+      //   return appIcon;
+      // }
     } catch (_) {
       log.info("App icon fetching failed");
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -494,14 +494,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.4"
-  installed_apps:
-    dependency: "direct main"
-    description:
-      name: installed_apps
-      sha256: dd2b7c531f91114cd6df447c56567593c9799ca83f057137ae719324ae0afd06
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.6.0"
   intl:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
   percent_indicator: ^4.2.3
   shared_preferences: ^2.3.1
   fl_chart: ^0.70.2
-  installed_apps: ^1.5.2
   package_info_plus: ^8.3.0
   sqflite: ^2.4.1
   path: ^1.9.0


### PR DESCRIPTION
# 🚀 Pull Request

## Brief Description
This pull request removes, with sadness, the shown icons in the activities list due to the QUERY_ALL_PACKAGES not being allowed to be used in production for our use case.

## GitHub Copilot Text
This pull request removes the usage of the `installed_apps` package and its related functionality due to restrictions on the `QUERY_ALL_PACKAGES` permission, which is not allowed for release on the Play Store. The most important changes include disabling the app icon fetching logic and removing the `installed_apps` dependency.

### Removal of `installed_apps` functionality:

* [`lib/utils/system_utils.dart`](diffhunk://#diff-fa53e970602244b2a9aef530e233a7a1e27b1d588854f4dcd1a4675529455f26L3-R16): Disabled the `getInstalledAppIcon` method by commenting out the logic that fetches app icons using the `installed_apps` package. Added a comment explaining that the method is not usable in production due to Play Store restrictions on the `QUERY_ALL_PACKAGES` permission.

### Dependency cleanup:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L28): Removed the `installed_apps` dependency (`^1.5.2`) since it is no longer used.